### PR TITLE
Develop

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,13 +16,15 @@ RUN apt update && apt install -y --no-install-recommends \
     postgresql-client \
     curl \
     nmap \
+    wget \
     gnupg \
     && rm -rf /var/lib/apt/lists/*
 
-# Instalar MongoDB Shell (mongosh) versión 7.0
-RUN curl -fsSL https://pgp.mongodb.com/server-7.0.asc | gpg --dearmor -o /usr/share/keyrings/mongodb-server-7.0.gpg \
-    && echo "deb [ signed-by=/usr/share/keyrings/mongodb-server-7.0.gpg ] https://repo.mongodb.org/apt/debian bookworm/mongodb-org/7.0 main" > /etc/apt/sources.list.d/mongodb-org-7.0.list \
-    && apt update && apt install -y mongodb-mongosh \
+# Add MongoDB repository and install mongosh
+RUN wget -qO - https://www.mongodb.org/static/pgp/server-6.0.asc | apt-key add - \
+    && echo "deb [ arch=amd64,arm64 ] https://repo.mongodb.org/apt/ubuntu focal/mongodb-org/6.0 multiverse" | tee /etc/apt/sources.list.d/mongodb-org-6.0.list \
+    && apt update \
+    && apt install -y mongodb-mongosh \
     && rm -rf /var/lib/apt/lists/*
 
 # Instalar dependencias Python

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,11 +17,11 @@ services:
         privileged: true
 
     mongo:
-        image: mongodb/mongodb-community-server:7.0.1-ubuntu2204
+        image: mongo
         restart: always
         environment:
-            MONGODB_INITDB_ROOT_USERNAME: root
-            MONGODB_INITDB_ROOT_PASSWORD: example
+            MONGO_INITDB_ROOT_USERNAME: root
+            MONGO_INITDB_ROOT_PASSWORD: example
         ports:
             - 27017:27017
         networks:


### PR DESCRIPTION
This pull request updates the Docker environment by modifying the MongoDB installation process and configuration. The changes include switching to a different MongoDB version, updating the repository setup, and altering the Docker Compose service configuration for MongoDB.

### Updates to MongoDB installation:

* [`Dockerfile`](diffhunk://#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557R19-R27): Changed the MongoDB repository to use version 6.0 instead of 7.0, updated the repository setup commands to use `wget` and `apt-key`, and replaced the MongoDB shell installation process accordingly.

### Updates to Docker Compose configuration:

* [`docker-compose.yml`](diffhunk://#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3L20-R24): Updated the MongoDB service to use the `mongo` image instead of `mongodb/mongodb-community-server:7.0.1-ubuntu2204`. Adjusted environment variable names from `MONGODB_INITDB_*` to `MONGO_INITDB_*` for compatibility.